### PR TITLE
Add support for script flags to filter questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,41 @@ Once this is completed you'll have access to the `polish_case_trainer` script th
 
 ## Usage Instructions:
 
+Run the script with the command:
+
+```bash
+polish_case_trainer
+```
+
 You'll be presented with a random noun (and its gender) plus a random adjective. Translation is not provided. You are then presented with a case and grammatical number (e.g. Plural Genitive) and prompted to provide the correct declined forms.
 
 If you succeed you are congratulated, if you fail you are given the correct answer. The program then moves on to another random adjective/noun pair and requests another case.
 
 It's best to accept that you will get most of them wrong to begin with. Keep playing and your rate of correct choices will increase. When you're getting a near-100% correct response rate, you have successfully internalised the root-change and ending-change patterns.
+
+You can give extra flags when running the script if you want to practise a specific case or number. The `--n` flag can be used to filter by singular or plural, and the `--c` flag to filter by case. When using these flags, specify the cases and numbers using the first letter of their name. For example, if you want to study only (d)ative and (l)ocative case examples, you would run the script using:
+
+```bash
+polish_case_trainer --c dl
+```
+
+If you want to study only (s)ingulars of any case you could run:
+
+```bash
+polish_case_trainer --n s
+```
+
+You can also combine the flags, for example if you want to focus on (a)ccusative (p)lurals:
+
+```bash
+polish_case_trainer --n p --c a
+```
+
+The flags can be used to filter for many cases, for example (d)ative, (l)ocative, (i)nstrumental, and (a)ccusative. The order is not important:
+
+```bash
+polish_case_trainer --c dlia
+```
 
 ## Sample Output:
 

--- a/bin/polish_case_trainer
+++ b/bin/polish_case_trainer
@@ -1,5 +1,27 @@
 #!/usr/bin/env python
+import sys
+import argparse
 from polish_case_trainer.controller import Controller
 
 if __name__ == "__main__":
-    Controller().main()
+    valid_cases = set(['n', 'a', 'g', 'd', 'i', 'l', 'v'])
+    valid_numbers = set(['s', 'p'])
+    cases = []
+    numbers = []
+
+    parser = argparse.ArgumentParser(description="Practise Polish cases.")
+    parser.add_argument('--n', help='specify numbers to practise')
+    parser.add_argument('--c', help='specify cases to practise')
+    args = parser.parse_args()
+
+    if args.n:
+        if not set(args.n).issubset(valid_cases):
+            raise ValueError
+        numbers = list(args.n)
+    if args.c:
+        if set(args.c).issubset(valid_cases):
+            raise ValueError
+        cases = list(args.c)
+
+    ctrl = Controller(number_options=numbers, case_options=cases)
+    ctrl.main()

--- a/polish_case_trainer/controller.py
+++ b/polish_case_trainer/controller.py
@@ -9,10 +9,17 @@ from .word import GenderNotSupported
 
 class Controller:
 
-    def __init__(self):
+    def __init__(self, number_options=[], case_options=[]):
         word_repository = WordRepository()
         word_factory = WordFactory()
         self.word_service = WordService(word_repository, word_factory)
+        self.options = {'number': ['singular', 'plural'],
+                            'case': ['nominative', 'accusative', 'genitive',
+                             'dative', 'instrumental', 'locative', 'vocative']}
+        if number_options:
+            self.options['number'] = [n for n in self.options['number'] if n[0] in number_options]
+        if case_options:
+            self.options['case'] = [case for case in self.options['case'] if case[0] in case_options]
 
     def main(self):
         # Opportunity to add a menu for other game modes here
@@ -45,8 +52,9 @@ class Controller:
             if not noun.list_case_forms():
                 continue
             number, case = random.choice(noun.list_case_forms())
-            if adjective.supports(number, case):
-                return noun, adjective, number, case
+            if number in self.options['number'] and case in self.options['case']:
+                if adjective.supports(number, case):
+                    return noun, adjective, number, case
 
     def _print_instructions(self, noun, adjective, number, case):
         print u"Noun: {} ({})\nAdjective: {}\nDecline for {} {}\n".format(


### PR DESCRIPTION
Hey!

I had a first go at adding support for testing only certain cases or numbers. I ended up trying out an interface with terminal flags for case and number because it seemed simplest for now rather than making users specify every time by requesting raw input inside the script... what do you think?

I also updated the readme with a few examples of how the flags can be used, and also added another feature idea I had.

I only spent about an hour and half on this so no worries if you have a different idea about a way that would be better, I'm happy to have another go doing it a different way :)